### PR TITLE
Fallback for localStorage in IE11 and below

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -640,6 +640,20 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
         };
     }
 
+    window.tempStorage = null;
+
+    // Does this browser support localStorage?
+    try {
+        window.tempStorage = window.localStorage;
+    } catch (e) {}
+
+    // Does this browser support sessionStorage?
+    try {
+        if (!window.tempStorage) window.tempStorage = window.sessionStorage;
+    } catch (e) {
+        window.localStorage = window.tempStorage;
+    }
+
     var ExpiringStorage = function () {
         function ExpiringStorage() {
             (0, _classCallCheck3.default)(this, ExpiringStorage);
@@ -648,29 +662,35 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
         (0, _createClass3.default)(ExpiringStorage, [{
             key: "get",
             value: function get(key) {
-                var cached = JSON.parse(localStorage.getItem(key));
+                if (localStorage) {
+                    var cached = JSON.parse(localStorage.getItem(key));
 
-                if (!cached) {
+                    if (!cached) {
+                        return null;
+                    }
+
+                    var expires = new Date(cached.expires);
+
+                    if (expires < new Date()) {
+                        localStorage.removeItem(key);
+                        return null;
+                    }
+
+                    return cached.value;
+                } else {
                     return null;
                 }
-
-                var expires = new Date(cached.expires);
-
-                if (expires < new Date()) {
-                    localStorage.removeItem(key);
-                    return null;
-                }
-
-                return cached.value;
             }
         }, {
             key: "set",
             value: function set(key, value, lifeTimeInMinutes) {
-                var currentTime = new Date().getTime();
+                if (localStorage) {
+                    var currentTime = new Date().getTime();
 
-                var expires = new Date(currentTime + lifeTimeInMinutes * 60000);
+                    var expires = new Date(currentTime + lifeTimeInMinutes * 60000);
 
-                localStorage.setItem(key, JSON.stringify({ value: value, expires: expires }));
+                    localStorage.setItem(key, JSON.stringify({ value: value, expires: expires }));
+                }
             }
         }]);
         return ExpiringStorage;

--- a/src/expiringStorage.js
+++ b/src/expiringStorage.js
@@ -1,29 +1,49 @@
+window.tempStorage = null;
+
+// Does this browser support localStorage?
+try {
+    window.tempStorage = window.localStorage;
+} catch (e) {}
+
+// Does this browser support sessionStorage?
+try {
+    if (!window.tempStorage) window.tempStorage = window.sessionStorage;
+} catch (e) {
+    window.localStorage = window.tempStorage;
+}
+
 class ExpiringStorage {
     get(key) {
-        const cached = JSON.parse(
-            localStorage.getItem(key)
-        );
+        if (localStorage) {
+            const cached = JSON.parse(
+                localStorage.getItem(key)
+            );
 
-        if (! cached) {
+            if (! cached) {
+                return null;
+            }
+
+            const expires = new Date(cached.expires);
+
+            if (expires < new Date()) {
+                localStorage.removeItem(key);
+                return null;
+            }
+
+            return cached.value;
+        } else {
             return null;
         }
-
-        const expires = new Date(cached.expires);
-
-        if (expires < new Date()) {
-            localStorage.removeItem(key);
-            return null;
-        }
-
-        return cached.value;
     }
 
     set(key, value, lifeTimeInMinutes) {
-        const currentTime = new Date().getTime();
+        if (localStorage) {
+            const currentTime = new Date().getTime();
 
-        const expires = new Date(currentTime + lifeTimeInMinutes * 60000);
+            const expires = new Date(currentTime + lifeTimeInMinutes * 60000);
 
-        localStorage.setItem(key, JSON.stringify({ value, expires }));
+            localStorage.setItem(key, JSON.stringify({ value, expires }));
+        }
     }
 }
 


### PR DESCRIPTION
Designed to solve: https://sentry.io/datacamp/enterprise-frontend/issues/897404206/events/0820f6ca8efe42a4b9bd168f5556d8b0/ and similar.

It seems like the issue is in compatibility mode and other edge case IE11 and below interactions with the site, touching `window.localStorage` raises an "Access Denied" error.

Idea behind this PR is that we:

- Test for `window.localStorage` in a catch by assigning it to `window.tempStorage`
- If that errors, then test for `sessionStorage` so that can be used in place of `localStorage`
- If even that still errors, set `window.localStorage` to `null`
- Wrap the calls to `ExpiringStorage.get/set` in checks that `localStorage` is not `null`

Confirmed working in Chrome, Safari, Firefox and IE11.